### PR TITLE
[config] Add forward routing features and geo cache TTL

### DIFF
--- a/application/development.config.json
+++ b/application/development.config.json
@@ -29,6 +29,7 @@
 	},
 	"features": {
 		"platforms": {
+            "geoContextCacheTtl":3600,
 		  "ios": {
 			"buysell": {
 			  "enabled": true,
@@ -49,7 +50,21 @@
 			  "unallowedCountries": []
 			}
 		  }
-		}
+		},
+        "forward": {
+              "directBroadcast": {
+                "enabled": true,
+                "networks": ["ton", "avalanche", "arbitrum", "optimism"]
+              },
+              "gasless": {
+                "enabled": true,
+                "networks": ["bsc", "solana", "polygon", "xrp", "base"]
+              },
+              "gaslessV1": {
+                "enabled": true,
+                "networks": ["ethereum", "tron", "bitcoin"]
+              }
+        }
 	  },
 	"feature": {
 		"enableGaslessTransfer": true,

--- a/application/preproduction.config.json
+++ b/application/preproduction.config.json
@@ -26,7 +26,10 @@
     "exportLock": false
   },
 	"features": {
+        
     "platforms": {
+        "geoContextCacheTtl":3600,
+
       "ios": {
         "buysell": {
           "enabled": true,
@@ -47,7 +50,21 @@
           "unallowedCountries": []
         }
       }
-    }
+    },
+    "forward": {
+          "directBroadcast": {
+            "enabled": true,
+            "networks": ["ton", "avalanche", "arbitrum", "optimism"]
+          },
+          "gasless": {
+            "enabled": true,
+            "networks": ["bsc", "solana","polygon", "xrp","base"]
+          },
+          "gaslessV1": {
+            "enabled": true,
+            "networks": ["ethereum", "tron", "bitcoin"]
+          }
+        }
   },
   "feature": {
     "enableGaslessTransfer": true,

--- a/application/production.config.json
+++ b/application/production.config.json
@@ -27,6 +27,7 @@
 	},
 	"features": {
 		"platforms": {
+            "geoContextCacheTtl":3600,
 		  "ios": {
 			"buysell": {
 			  "enabled": true,
@@ -47,7 +48,21 @@
 			  "unallowedCountries": []
 			}
 		  }
-		}
+		},
+        "forward": {
+              "directBroadcast": {
+                "enabled": true,
+                "networks": ["ton", "avalanche", "arbitrum", "optimism"]
+              },
+              "gasless": {
+                "enabled": true,
+                "networks": ["bsc", "solana","polygon", "xrp","ethereum", "tron", "bitcoin","base"]
+              },
+              "gaslessV1": {
+                "enabled": true,
+                "networks": []
+              }
+            }
 	},
 	"feature": {
 		"enableGaslessTransfer": true,


### PR DESCRIPTION
## Summary

Adds forward routing configuration (direct broadcast, gasless legacy, gasless V1) and geo context cache TTL for platform features across development, preproduction, and production.

## Changes

- `features.forward.directBroadcast` — enabled, networks: ton, avalanche, arbitrum, optimism
- `features.forward.gasless` — enabled, networks: bsc, solana, polygon, xrp, base
- `features.forward.gaslessV1` — enabled, networks: ethereum, tron, bitcoin
- `features.platforms.geoContextCacheTtl` — 3600 seconds
- JSON formatting aligned across environments

## Affected

- application/development.config.json
- application/preproduction.config.json
- application/production.config.json