### PR TITLE
[config] Remove GBR from iOS buysell unallowed countries (preproduction)

### DIFF
--- a/application/preproduction.config.json
+++ b/application/preproduction.config.json
@@ -33,7 +33,7 @@
       "ios": {
         "buysell": {
           "enabled": true,
-          "unallowedCountries": ["GBR"]
+          "unallowedCountries": []
         },
         "crossChainSwap": {
           "enabled": true,


### PR DESCRIPTION
## Summary

Align preproduction with development and production: allow iOS buysell for users in Great Britain.

## Changes

- Preproduction iOS `buysell.unallowedCountries`: `["GBR"]` → `[]`.

## Affected

- application/preproduction.config.json