### PR TITLE
[config] Remove GBR from iOS crossChainSwap unallowed countries (preproduction)

### DIFF
--- a/application/preproduction.config.json
+++ b/application/preproduction.config.json
@@ -37,7 +37,7 @@
         },
         "crossChainSwap": {
           "enabled": true,
-          "unallowedCountries":["AFG","DZA","BOL","EGY","MAR","NPL","QAT","SAU","USA","GBR"] 
+          "unallowedCountries":["AFG","DZA","BOL","EGY","MAR","NPL","QAT","SAU","USA"] 
         }
       },
       "android": {


### PR DESCRIPTION
## Summary

Allow iOS crossChainSwap for users in Great Britain in preproduction by removing GBR from the country block list.

## Changes

- Preproduction iOS `crossChainSwap.unallowedCountries`: removed `GBR` from the list.

## Affected

- application/preproduction.config.json