### PR TITLE
config(app): align preprod forward gasless networks with gasless V1

### DIFF
--- a/application/preproduction.config.json
+++ b/application/preproduction.config.json
@@ -58,11 +58,11 @@
           },
           "gasless": {
             "enabled": true,
-            "networks": ["bsc", "solana","polygon", "xrp","base"]
+            "networks": ["ethereum", "tron", "bitcoin","bsc", "solana","polygon", "xrp","base"]
           },
           "gaslessV1": {
             "enabled": true,
-            "networks": ["ethereum", "tron", "bitcoin"]
+            "networks": []
           }
         }
   },


### PR DESCRIPTION
## Summary

Updates preproduction forward routing so `gasless` and `gaslessV1` match the intended split: main gasless covers ethereum, tron, and bitcoin together with the existing networks; gasless V1 no longer lists those chains.

## Changes

- `features.forward.gasless` — networks extended with `ethereum`, `tron`, `bitcoin` (alongside `bsc`, `solana`, `polygon`, `xrp`, `base`)
- `features.forward.gaslessV1` — `networks` set to `[]`

## Affected

- `application/preproduction.config.json`