### PR TITLE
Application feature flags: forward gasless routing and preprod compliance updates

### DIFF
--- a/application/development.config.json
+++ b/application/development.config.json
@@ -33,7 +33,7 @@
 		  "ios": {
 			"buysell": {
 			  "enabled": true,
-			  "unallowedCountries": []
+			  "unallowedCountries": ["GBR"]
 			},
 			"crossChainSwap": {
 			  "enabled": true,

--- a/application/development.config.json
+++ b/application/development.config.json
@@ -29,6 +29,7 @@
 	},
 	"features": {
 		"platforms": {
+            "geoContextCacheTtl":3600,
 		  "ios": {
 			"buysell": {
 			  "enabled": true,
@@ -49,7 +50,21 @@
 			  "unallowedCountries": []
 			}
 		  }
-		}
+		},
+        "forward": {
+              "directBroadcast": {
+                "enabled": true,
+                "networks": ["ton", "avalanche", "arbitrum", "optimism"]
+              },
+              "gasless": {
+                "enabled": true,
+                "networks": ["bsc", "solana", "polygon", "xrp", "base"]
+              },
+              "gaslessV1": {
+                "enabled": true,
+                "networks": ["ethereum", "tron", "bitcoin"]
+              }
+        }
 	  },
 	"feature": {
 		"enableGaslessTransfer": true,

--- a/application/development.config.json
+++ b/application/development.config.json
@@ -33,7 +33,7 @@
 		  "ios": {
 			"buysell": {
 			  "enabled": true,
-			  "unallowedCountries": ["GBR"]
+			  "unallowedCountries": []
 			},
 			"crossChainSwap": {
 			  "enabled": true,

--- a/application/preproduction.config.json
+++ b/application/preproduction.config.json
@@ -33,7 +33,7 @@
       "ios": {
         "buysell": {
           "enabled": true,
-          "unallowedCountries": []
+          "unallowedCountries": ["GBR"]
         },
         "crossChainSwap": {
           "enabled": true,

--- a/application/preproduction.config.json
+++ b/application/preproduction.config.json
@@ -58,11 +58,11 @@
           },
           "gasless": {
             "enabled": true,
-            "networks": ["tron", "bitcoin", "bsc", "solana", "xrp"]
+            "networks": []
           },
           "gaslessV1": {
             "enabled": true,
-            "networks": ["ethereum", "polygon", "base"]
+            "networks": ["ethereum", "polygon", "base", "tron", "bitcoin", "bsc", "solana", "xrp"]
           }
         }
   },

--- a/application/preproduction.config.json
+++ b/application/preproduction.config.json
@@ -37,7 +37,7 @@
         },
         "crossChainSwap": {
           "enabled": true,
-          "unallowedCountries":["AFG","DZA","BOL","EGY","MAR","NPL","QAT","SAU","USA","GBR"] 
+          "unallowedCountries":["AFG","DZA","BOL","EGY","MAR","NPL","QAT","SAU","USA"] 
         }
       },
       "android": {

--- a/application/preproduction.config.json
+++ b/application/preproduction.config.json
@@ -58,11 +58,11 @@
           },
           "gasless": {
             "enabled": true,
-            "networks": ["ethereum", "tron", "bitcoin","bsc", "solana","polygon", "xrp","base"]
+            "networks": ["tron", "bitcoin", "bsc", "solana", "xrp"]
           },
           "gaslessV1": {
             "enabled": true,
-            "networks": []
+            "networks": ["ethereum", "polygon", "base"]
           }
         }
   },

--- a/application/preproduction.config.json
+++ b/application/preproduction.config.json
@@ -33,7 +33,7 @@
       "ios": {
         "buysell": {
           "enabled": true,
-          "unallowedCountries": ["GBR"]
+          "unallowedCountries": []
         },
         "crossChainSwap": {
           "enabled": true,

--- a/application/preproduction.config.json
+++ b/application/preproduction.config.json
@@ -26,7 +26,10 @@
     "exportLock": false
   },
 	"features": {
+        
     "platforms": {
+        "geoContextCacheTtl":3600,
+
       "ios": {
         "buysell": {
           "enabled": true,
@@ -47,7 +50,21 @@
           "unallowedCountries": []
         }
       }
-    }
+    },
+    "forward": {
+          "directBroadcast": {
+            "enabled": true,
+            "networks": ["ton", "avalanche", "arbitrum", "optimism"]
+          },
+          "gasless": {
+            "enabled": true,
+            "networks": ["bsc", "solana","polygon", "xrp","base"]
+          },
+          "gaslessV1": {
+            "enabled": true,
+            "networks": ["ethereum", "tron", "bitcoin"]
+          }
+        }
   },
   "feature": {
     "enableGaslessTransfer": true,

--- a/application/preproduction.config.json
+++ b/application/preproduction.config.json
@@ -58,11 +58,11 @@
           },
           "gasless": {
             "enabled": true,
-            "networks": ["bsc", "solana","polygon", "xrp","base"]
+            "networks": ["ethereum", "tron", "bitcoin","bsc", "solana","polygon", "xrp","base"]
           },
           "gaslessV1": {
             "enabled": true,
-            "networks": ["ethereum", "tron", "bitcoin"]
+            "networks": []
           }
         }
   },

--- a/application/production.config.json
+++ b/application/production.config.json
@@ -27,6 +27,7 @@
 	},
 	"features": {
 		"platforms": {
+            "geoContextCacheTtl":3600,
 		  "ios": {
 			"buysell": {
 			  "enabled": true,
@@ -47,7 +48,21 @@
 			  "unallowedCountries": []
 			}
 		  }
-		}
+		},
+        "forward": {
+              "directBroadcast": {
+                "enabled": true,
+                "networks": ["ton", "avalanche", "arbitrum", "optimism"]
+              },
+              "gasless": {
+                "enabled": true,
+                "networks": ["bsc", "solana","polygon", "xrp","ethereum", "tron", "bitcoin","base"]
+              },
+              "gaslessV1": {
+                "enabled": true,
+                "networks": []
+              }
+            }
 	},
 	"feature": {
 		"enableGaslessTransfer": true,

--- a/application/production.config.json
+++ b/application/production.config.json
@@ -31,7 +31,7 @@
 		  "ios": {
 			"buysell": {
 			  "enabled": true,
-			  "unallowedCountries": []
+			  "unallowedCountries": ["GBR"]
 			},
 			"crossChainSwap": {
 			  "enabled": true,

--- a/application/production.config.json
+++ b/application/production.config.json
@@ -31,7 +31,7 @@
 		  "ios": {
 			"buysell": {
 			  "enabled": true,
-			  "unallowedCountries": ["GBR"]
+			  "unallowedCountries": []
 			},
 			"crossChainSwap": {
 			  "enabled": true,


### PR DESCRIPTION
## Summary
This merge brings `staging` into `main` for application JSON configs. It adds forward-routing feature flags (`directBroadcast`, `gasless`, `gaslessV1`) and a platform-level `geoContextCacheTtl`. Preproduction is aligned with gasless V1 routing (legacy `gasless` kept enabled with an empty `networks` list) and updates iOS geo restrictions for buysell and cross-chain swap (including GBR handling). Development and production receive the same structural `features.forward` / `geoContextCacheTtl` additions with environment-appropriate gasless network splits.


## Changes
- **`features.platforms.geoContextCacheTtl`** — set to `3600` (dev, preprod, prod).
- **`features.forward`** — added with:
  - `directBroadcast` — TON, Avalanche, Arbitrum, Optimism (all envs).
  - **`preproduction`:** `gasless.networks` → `[]`; `gaslessV1.networks` → ethereum, polygon, base, tron, bitcoin, bsc, solana, xrp.
  - **`development` / `production`:** gasless vs gaslessV1 network lists per existing staging policy (dev splits networks across legacy vs V1; prod keeps legacy gasless populated and `gaslessV1.networks` empty).
- **Preprod iOS** — `crossChainSwap.unallowedCountries`: GBR removed from the list (aligned with prior buysell GBR work on staging).
- **JSON** — trailing newlines normalized at EOF where touched.


## Affected
- `application/development.config.json`
- `application/preproduction.config.json`
- `application/production.config.json`