### PR TITLE
Align forward routing and geo restrictions across application configs

### DIFF
--- a/application/preproduction.config.json
+++ b/application/preproduction.config.json
@@ -36,7 +36,7 @@
 		  "crossChainSwap": {
 			"enabled": true,
 			"swpEnabled": true,
-			"unallowedCountries": ["AFG", "DZA", "BOL", "EGY", "MAR", "NPL", "QAT", "SAU", "USA"]
+			"unallowedCountries": ["AFG", "DZA", "BOL", "EGY", "MAR", "NPL", "QAT", "SAU", "USA", "GBR"]
 		  }
 		},
 		"android": {


### PR DESCRIPTION
## Summary

This PR promotes the current staging config changes to main for the application JSON files.

## Changes

- Added `GBR` to iOS `buysell.unallowedCountries` across  preproduction.

## Affected files

- `config/application/preproduction.config.json`