### PR TITLE
Promote staging to main for cross-chain swap geo config

### DIFF
--- a/application/development.config.json
+++ b/application/development.config.json
@@ -50,6 +50,13 @@
 						"QAT",
 						"SAU",
 						"GBR"
+					],
+					"swpCountries": [],
+					"swapCountries": [
+						"TUR",
+						"ISR",
+						"RUS",
+						"KHM"
 					]
 				}
 			},
@@ -61,7 +68,9 @@
 				"crossChainSwap": {
 					"enabled": true,
 					"swpEnabled": true,
-					"unallowedCountries": []
+					"unallowedCountries": [],
+					"swpCountries": [],
+					"swapCountries": []
 				}
 			}
 		},

--- a/application/preproduction.config.json
+++ b/application/preproduction.config.json
@@ -58,6 +58,7 @@
 				},
 				"crossChainSwap": {
 					"enabled": true,
+					"swpEnabled": false,
 					"unallowedCountries": []
 				}
 			}

--- a/application/preproduction.config.json
+++ b/application/preproduction.config.json
@@ -48,6 +48,13 @@
 						"QAT",
 						"SAU",
 						"GBR"
+					],
+					"swpCountries": [],
+					"swapCountries": [
+						"TUR",
+						"ISR",
+						"RUS",
+						"KHM"
 					]
 				}
 			},
@@ -58,8 +65,9 @@
 				},
 				"crossChainSwap": {
 					"enabled": true,
-					"swpEnabled": false,
-					"unallowedCountries": []
+					"unallowedCountries": [],
+					"swpCountries": [],
+					"swapCountries": []
 				}
 			}
 		},

--- a/application/production.config.json
+++ b/application/production.config.json
@@ -48,6 +48,13 @@
 						"QAT",
 						"SAU",
 						"GBR"
+					],
+					"swpCountries": [],
+					"swapCountries": [
+						"TUR",
+						"ISR",
+						"RUS",
+						"KHM"
 					]
 				}
 			},
@@ -58,7 +65,9 @@
 				},
 				"crossChainSwap": {
 					"enabled": true,
-					"unallowedCountries": []
+					"unallowedCountries": [],
+					"swpCountries": [],
+					"swapCountries": []
 				}
 			}
 		},


### PR DESCRIPTION
## Summary
Promotes staging to main for application JSON configs. This release rolls up cross-chain swap geo configuration updates by adding explicit `swpCountries` and `swapCountries` lists for iOS and Android platform settings across development, preproduction, and production.
## Changes (high level)
Cross-chain swap geo config — adds explicit empty `swpCountries` lists.
iOS swap availability — adds `swapCountries` for TUR, ISR, RUS, and KHM.
Android alignment — adds empty `swpCountries` and `swapCountries` lists for cross-chain swap settings.
Formatting — ensures application JSON configs end with a newline.
## Affected files
application/development.config.json
application/preproduction.config.json
application/production.config.json
## Pre-merge checks
All three application configs on staging parse as valid JSON.
Merge conflict check for `origin/main` and `origin/staging` completes without conflicts.
No other paths changed vs main, only the three files above.
git diff --check passes without whitespace errors.
