### PR TITLE
Promote staging to main: route Bitcoin and Solana via gaslessV1

### DIFF
--- a/application/production.config.json
+++ b/application/production.config.json
@@ -206,10 +206,8 @@
 			"gasless": {
 				"enabled": true,
 				"networks": [
-					"solana",
 					"ethereum",
-					"tron",
-					"bitcoin"
+					"tron"
 				]
 			},
 			"gaslessV1": {
@@ -220,7 +218,9 @@
 					"optimism",
 					"bsc",
 					"polygon",
-					"base"
+					"base",
+					"bitcoin",
+					"solana"
 				]
 			}
 		}


### PR DESCRIPTION
## Summary

Promote the latest remote `staging` changes into `main`.

This update changes production forwarding config by moving `bitcoin` and `solana` from legacy `gasless` routing to `gaslessV1`.

## Changes

- `features.forward.gasless.networks`
  - removed: `bitcoin`, `solana`
  - current: `ethereum`, `tron`
- `features.forward.gaslessV1.networks`
  - added: `bitcoin`, `solana`

## Included commits

- `0a1a844` Merge pull request #125 from Ironwallet/ci-json-sync-17356-21570
- `5166f2d` Sync application JSON configs

## Files changed

- `application/production.config.json`

## Test plan

- [x] Validate `origin/main` production config JSON parsing
- [x] Validate `origin/staging` production config JSON parsing
- [x] Verify `bitcoin` moved from `gasless` to `gaslessV1`
- [x] Verify `solana` moved from `gasless` to `gaslessV1`
- [x] Verify `gasless.networks` in staging is exactly `ethereum`, `tron`
- [x] Verify no overlap between `gasless` and `gaslessV1` in staging
- [x] Verify `bitcoin` and `solana` are newly present in `gaslessV1` vs `origin/main`

Validation result: **7/7 checks passed**.